### PR TITLE
Fix removing non-leftmost tab that has a separator BoxView to its left

### DIFF
--- a/Tabs/Tabs/TabHostView.cs
+++ b/Tabs/Tabs/TabHostView.cs
@@ -760,6 +760,7 @@ namespace Sharpnado.Tabs
             {
                 _grid.Children.RemoveAt(tabItemIndex - 1);
                 _grid.ColumnDefinitions.RemoveAt(tabItemIndex - 1);
+                tabItemIndex--;
             }
 
             _grid.Children.RemoveAt(tabItemIndex);


### PR DESCRIPTION
- All but the leftmost tab have a BoxView left of the tab itself
- When one of those tabs is removed, the BoxView is removed first
- But that throws off the # of items in grid.Children and grid.ColumnDefinitions
- So then the tab itself is not removed correctly
- Removing the rightmost tab throws an ArgumentOutOfRangeException
- Removing a tab to the left of the right-most tab causes incorrect tabs to be displayed

This change allows any of the tabs to be removed in any sequence