### PR TITLE
Make viewswitcher implement IAnimatableReveal

### DIFF
--- a/Tabs/Tabs/ViewSwitcher.cs
+++ b/Tabs/Tabs/ViewSwitcher.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms;
 
 namespace Sharpnado.Tabs
 {
-    public class ViewSwitcher : Grid, IDisposable
+    public class ViewSwitcher : Grid, IDisposable, IAnimatableReveal
     {
         public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(
             nameof(SelectedIndex),


### PR DESCRIPTION
If a viewswitcher is a child of a viewswitcher, the first tab of the child viewswitcher will now animate in correctly when it is switched to - for:

![spanish](https://user-images.githubusercontent.com/6513834/201117784-905a730a-d65f-47b1-9a94-77dd187b2553.jpg)

(I presume this was always the intention, since ViewSwitcher already has the animate boolean, just not the IAnimatableReveal interface.)