### PR TITLE
When the SelectedIndex is updated, make sure the newly selected tab i…

### DIFF
--- a/Tabs/Tabs/TabHostView.cs
+++ b/Tabs/Tabs/TabHostView.cs
@@ -555,7 +555,41 @@ namespace Sharpnado.Tabs
             }
 
             SelectedIndex = selectedIndex;
+
+            // If the scroll type is animated, then ensure the tab is brought into focus
+            if (TabType == TabType.Scrollable && selectedIndex > 0 && selectedIndex < _selectableTabs.Count)
+            {
+                AnimateScrollTo(_scrollView, _selectableTabs[selectedIndex].X);
+            }
+
             InternalLogger.Debug(Tag, () => $"SelectedIndex: {SelectedIndex}");
+        }
+
+        private async Task AnimateScrollTo(ScrollView scrollView, double position)
+        {
+            // Define the duration of the animation
+            const int duration = 150; // milliseconds
+
+            // Current position
+            double startPosition = scrollView.ScrollX;
+
+            // The easing function you want to use
+            Easing customEasing = Easing.CubicInOut;
+
+            await Task.Run(() =>
+            {
+                new Animation(
+                    callback: d =>
+                    {
+                            // The interpolated position between start and target position
+                            double newX = startPosition + (position - startPosition) * d;
+                            scrollView.ScrollToAsync(newX, 0, false);
+                        },
+                    start: 0,
+                    end: 1,
+                    easing: customEasing)
+                    .Commit(scrollView, "CustomScroll", length: duration);
+            });
         }
 
         private bool _fromTabItemTapped;


### PR DESCRIPTION
…s animated/scrolled to if it is off screen

Fixes #9 and #81 

The most straightforward solution would be to do:
```c#
scrollView.ScrollToAsync(_selectableTabs[SelectedIndex], ScrollToPosition.Start, true);
```

However, the animation speed here is a bit on the slow side. 

The other option would be to do something like:
```c#
var animation = new Animation(x => {
  scrollView.ScrollToAsync(x, 0, true)
}, 1, 1, Easing.CubeInOut);

animation.Commit(_scrollView, "animation", _scrolLView.ScrollX, _selectedTabs[SelectedIndex].X);
```

However, the `rate` at its lowest value, 1 is still too high for the animation to appear fast. So Instead, the animation is done by hand.


