### PR TITLE
Fix crash in .NET 9

### DIFF
--- a/Maui.Tabs/Maui.Tabs.csproj
+++ b/Maui.Tabs/Maui.Tabs.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->
 		<RootNamespace>Sharpnado.Tabs</RootNamespace>
-		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
+		<UseMaui>true</UseMaui>
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
@@ -128,6 +127,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)">
+			<PrivateAssets>all</PrivateAssets>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</PackageReference>
 		<PackageReference Include="Sharpnado.TaskMonitor" Version="1.0.2" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
 			<PrivateAssets>all</PrivateAssets>

--- a/Tabs/Tabs/DelayedView.cs
+++ b/Tabs/Tabs/DelayedView.cs
@@ -14,7 +14,7 @@ public class DelayedView<TView> : LazyView<TView>
             async () =>
                 {
                     View? view = null;
-                    if (Device.RuntimePlatform == Device.Android)
+                    if (DeviceInfo.Platform == DevicePlatform.Android)
                     {
                         await Task.Run(
                             () =>

--- a/Tabs/Tabs/TabHostView.cs
+++ b/Tabs/Tabs/TabHostView.cs
@@ -7,6 +7,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
+using Microsoft.Maui.Controls.Shapes;
+
 
 #if !NET6_0_OR_GREATER
 using Sharpnado.Shades;
@@ -122,7 +124,7 @@ namespace Sharpnado.Tabs
         private const string Tag = nameof(TabHostView);
 
         private readonly Grid _grid;
-        private readonly Frame _frame;
+        private readonly Border _border;
         private List<TabItem> _selectableTabs = new();
 
         private INotifyCollectionChanged _currentNotifyCollection;
@@ -154,12 +156,13 @@ namespace Sharpnado.Tabs
                 BackgroundColor = BackgroundColor,
             };
 
-            _frame = new Frame
+            _border = new Border
             {
                 Padding = 0,
-                HasShadow = false,
-                IsClippedToBounds = true,
-                CornerRadius = CornerRadius,
+                StrokeShape = new RoundRectangle()
+                {
+                    CornerRadius = CornerRadius,
+                },
 #if NET6_0_OR_GREATER
                 BackgroundColor = Colors.Transparent,
 #else
@@ -167,7 +170,7 @@ namespace Sharpnado.Tabs
 #endif
                 HorizontalOptions = LayoutOptions.Fill,
                 VerticalOptions = LayoutOptions.Fill,
-                BorderColor = SegmentedOutlineColor,
+                Stroke = SegmentedOutlineColor,
             };
 
             UpdateTabType();
@@ -446,12 +449,12 @@ namespace Sharpnado.Tabs
 
         private void UpdateSegmentedOutlineColor()
         {
-            if (_frame == null)
+            if (_border == null)
             {
                 return;
             }
 
-            _frame.BorderColor = SegmentedOutlineColor;
+            _border.Stroke = SegmentedOutlineColor;
             foreach (var separator in _grid.Children.Where(c => c is BoxView))
             {
 
@@ -467,7 +470,7 @@ namespace Sharpnado.Tabs
         {
             if (IsSegmented)
             {
-                if (_frame == null)
+                if (_border == null)
                 {
                     return;
                 }
@@ -477,7 +480,7 @@ namespace Sharpnado.Tabs
 #else
                 _grid.BackgroundColor = Color.Transparent;
 #endif
-                _frame.BackgroundColor = BackgroundColor;
+                _border.BackgroundColor = BackgroundColor;
                 return;
             }
 
@@ -487,7 +490,7 @@ namespace Sharpnado.Tabs
             }
 
 #if NET6_0_OR_GREATER
-            _frame.BackgroundColor = Colors.Transparent;
+            _border.BackgroundColor = Colors.Transparent;
 #else
             _frame.BackgroundColor = Color.Transparent;
 #endif
@@ -496,12 +499,15 @@ namespace Sharpnado.Tabs
 
         private void UpdateCornerRadius()
         {
-            if (_frame == null)
+            if (_border == null)
             {
                 return;
             }
 
-            _frame.CornerRadius = CornerRadius;
+            _border.StrokeShape = new RoundRectangle()
+            {
+                CornerRadius = CornerRadius,
+            };
         }
 
         private void AddSeparators()
@@ -583,8 +589,8 @@ namespace Sharpnado.Tabs
 
             if (IsSegmented)
             {
-                _frame.Content = _grid;
-                _frame.BackgroundColor = BackgroundColor;
+                _border.Content = _grid;
+                _border.BackgroundColor = BackgroundColor;
 
 #if NET6_0_OR_GREATER
                 _grid.BackgroundColor = Colors.Transparent;
@@ -594,10 +600,10 @@ namespace Sharpnado.Tabs
             }
             else
             {
-                _frame.Content = null;
+                _border.Content = null;
 
 #if NET6_0_OR_GREATER
-                _frame.BackgroundColor = Colors.Transparent;
+                _border.BackgroundColor = Colors.Transparent;
 #else
                 _frame.BackgroundColor = Color.Transparent;
 #endif
@@ -619,7 +625,7 @@ namespace Sharpnado.Tabs
 
                 if (IsSegmented)
                 {
-                    _scrollView.Content = _frame;
+                    _scrollView.Content = _border;
                 }
                 else
                 {
@@ -645,7 +651,7 @@ namespace Sharpnado.Tabs
             {
                 if (IsSegmented)
                 {
-                    base.Content = _frame;
+                    base.Content = _border;
                 }
                 else
                 {
@@ -707,7 +713,7 @@ namespace Sharpnado.Tabs
                 return;
             }
 
-            if (Device.RuntimePlatform == Device.UWP)
+            if (DeviceInfo.Platform == DevicePlatform.WinUI)
             {
                 tabItem.GestureRecognizers.Add(
                     new TapGestureRecognizer { Command = TabItemTappedCommand, CommandParameter = tabItem });


### PR DESCRIPTION
- Converts project to a newer class library. Explicit TFM is no longer necessary
- Update obsoluted references with equivalents