### PR TITLE
Fix problems with non-interactable tabs on Android

### DIFF
--- a/Tabs/Tabs/TabHostView.cs
+++ b/Tabs/Tabs/TabHostView.cs
@@ -709,7 +709,7 @@ namespace Sharpnado.Tabs
                 return;
             }
 
-            if (DeviceInfo.Platform == DevicePlatform.WinUI)
+            if (DeviceInfo.Platform == DevicePlatform.WinUI || DeviceInfo.Platform == DevicePlatform.Android)
             {
                 tabItem.GestureRecognizers.Add(
                     new TapGestureRecognizer { Command = TabItemTappedCommand, CommandParameter = tabItem });


### PR DESCRIPTION
This should fix #84 and #120 AFAICS. Testing and feedback welcome.

@roubachof What was the original reason for using `TapGestureRecognizer` only on WinUI, but not on other platforms? On Android it actually seems to work well (and better than the tap command effects). Any reason why we couldn't use it on iOS as well? That would make the implementation more generic and require less platform-specific code ...