### PR TITLE
Update MauiSample to .NET 9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,12 +19,14 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'
+    - name: Restore workloads
+      run: dotnet workload restore MauiSample/MauiSample.sln
     - name: Restore dependencies
       run: dotnet restore MauiSample/MauiSample.sln
     - name: Build Maui Lib

--- a/Maui.Tabs/Platforms/iOS/TintableImageEffect.cs
+++ b/Maui.Tabs/Platforms/iOS/TintableImageEffect.cs
@@ -88,7 +88,7 @@ namespace Sharpnado.Tabs.iOS
         private async Task DelayedPost(int milliseconds, Action action)
         {
             await Task.Delay(milliseconds);
-            Device.BeginInvokeOnMainThread(action);
+            MainThread.BeginInvokeOnMainThread(action);
         }
     }
 }

--- a/Maui.Tabs/Platforms/iOS/TouchEffectPlatform.cs
+++ b/Maui.Tabs/Platforms/iOS/TouchEffectPlatform.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
-using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
 using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Platform;
 using ObjCRuntime;
 using Sharpnado.Tabs.Effects.iOS.GestureCollectors;
 using Sharpnado.Tabs.Effects.iOS.GestureRecognizers;
@@ -80,7 +80,7 @@ namespace Sharpnado.Tabs.Effects.iOS {
 
             InternalLogger.Debug($"UpdateEffectColor");
             _alpha = color.Alpha < 1.0 ? 1 : (float)0.3;
-            _layer.BackgroundColor = color.ToUIColor();
+            _layer.BackgroundColor = color.ToPlatform();
         }
 
         void BringLayer() {

--- a/MauiSample/MauiSample.csproj
+++ b/MauiSample/MauiSample.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
@@ -31,7 +31,7 @@
 		<ProvisioningType>automatic</ProvisioningType>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'=='net8.0-ios'">
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
 	  <CodesignKey>Apple Development: Created via API (K8Q3S2AN24)</CodesignKey>
 	  <CodesignProvision>VS: WildCard Development</CodesignProvision>
 	</PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
     "sdk": {
-      "version": "8.0.100",
+      "version": "9.0.0",
       "rollForward": "latestFeature"
     }
   }
-  


### PR DESCRIPTION
This PR updates the MauiSample to .NET 9 (but not yet Maui.Tabs itself). The MauiSample obtains additional TFMs for net9.0 (in addition to those of net8.0), so that one can choose whether one wants to build it with .NET 8 or .NET 9.

This should make it easier to reproduce problems like those in #116, and also it's a first step towards converting Maui.Tabs to .NET 9 as well (which will require a bit additional effort).