### PR TITLE
Fix AppThemeBinding when changing between dark and light modes

### DIFF
--- a/Maui.Tabs/TabHostView.PropertyChanged.cs
+++ b/Maui.Tabs/TabHostView.PropertyChanged.cs
@@ -299,7 +299,7 @@ public partial class TabHostView
     {
         InitializeIfNeeded();
 
-        Border.Stroke = SegmentedOutlineColor;
+        Border.BorderColor = SegmentedOutlineColor;
         foreach (var separator in _grid.Children.Where(c => c is BoxView))
         {
             ((BoxView)separator).Color = SegmentedOutlineColor;
@@ -330,10 +330,7 @@ public partial class TabHostView
     {
         InitializeIfNeeded();
 
-        Border.StrokeShape = new RoundRectangle
-        {
-            CornerRadius = CornerRadius,
-        };
+        Border.CornerRadius = CornerRadius;
     }
 
     private void AddSeparators()

--- a/Tabs/Tabs/TabHostView.cs
+++ b/Tabs/Tabs/TabHostView.cs
@@ -142,18 +142,16 @@ public partial class TabHostView : ContentView
             return;
         }
 
-        Border = new Border
+        Border = new Frame()
         {
             Padding = 0,
             BackgroundColor = Colors.Transparent,
             HorizontalOptions = LayoutOptions.Fill,
             VerticalOptions = LayoutOptions.Fill,
-            StrokeShape = new RoundRectangle
-            {
-                CornerRadius = CornerRadius,
-            },
-
-            Stroke = SegmentedOutlineColor,
+            HasShadow = false,
+            IsClippedToBounds = true,
+            CornerRadius = CornerRadius,
+            BorderColor = SegmentedOutlineColor,
         };
 
         _grid = new Grid
@@ -166,7 +164,7 @@ public partial class TabHostView : ContentView
         };
     }
 
-    public Border Border { get; private set; }
+    public Frame Border { get; private set; }
 
     public IEnumerable ItemsSource
     {


### PR DESCRIPTION
Fix AppThemeBinding when changing between dark and light modes. Replaced TabHostView border with a frame which allows the AppThemeBinding to properly update the underlying properties.