### PR TITLE
A tab button can now be set to not take the full space within the tab bar.

### DIFF
--- a/Tabs/Tabs/TabButton.cs
+++ b/Tabs/Tabs/TabButton.cs
@@ -46,6 +46,11 @@ namespace Sharpnado.Tabs
             typeof(double),
             typeof(TabButton));
 
+        public static readonly BindableProperty ExpandToTabSizeProperty = BindableProperty.Create(
+            nameof(ExpandToTabSize),
+            typeof(bool),
+            typeof(TabButton));
+
         private ImageButton _imageButton;
 
         public TabButton()
@@ -105,6 +110,16 @@ namespace Sharpnado.Tabs
         {
             get => (double)GetValue(ButtonCircleSizeProperty);
             set => SetValue(ButtonCircleSizeProperty, value);
+        }
+
+        /// <summary>
+        /// When this property is disabled, the button occupies the calculated width (for horizontal tab bars) or height (for vertical tab bars), letting other tabs' content be properly centered within the free space.
+        /// When this property is enabled, the button occupies the same width (for horizontal tab bars) or height (for vertical tab bars) as the other tabs.
+        /// </summary>
+        public bool ExpandToTabSize
+        {
+            get => (bool)GetValue(ExpandToTabSizeProperty);
+            set => SetValue(ExpandToTabSizeProperty, value);
         }
 
         protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
@@ -201,6 +216,7 @@ namespace Sharpnado.Tabs
             }
         }
 
+
         private void Initialize()
         {
             _imageButton = new ImageButton
@@ -215,6 +231,7 @@ namespace Sharpnado.Tabs
 
             Content = _imageButton;
 
+            ExpandToTabSize = true;
             IsSelectable = false;
 
             _imageButton.BackgroundColor = ButtonBackgroundColor;

--- a/Tabs/Tabs/TabHostView.cs
+++ b/Tabs/Tabs/TabHostView.cs
@@ -1,12 +1,10 @@
-﻿using System.Collections;
+﻿using Microsoft.Maui.Controls.Shapes;
+using Sharpnado.Tabs.Effects;
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows.Input;
-
-using Microsoft.Maui.Controls.Shapes;
-
-using Sharpnado.Tabs.Effects;
 
 namespace Sharpnado.Tabs;
 
@@ -420,7 +418,7 @@ public partial class TabHostView : ContentView
                 tabIndexInGrid,
                 new ColumnDefinition
                 {
-                    Width = TabType == TabType.Fixed ? GridLength.Star : GridLength.Auto,
+                    Width = ((TabType == TabType.Fixed) && ((tabItem is not TabButton tabButton) || tabButton.ExpandToTabSize)) ? GridLength.Star : GridLength.Auto,
                 });
 
             if (TabType == TabType.Scrollable)
@@ -449,7 +447,7 @@ public partial class TabHostView : ContentView
                 tabIndexInGrid,
                 new RowDefinition
                 {
-                    Height = TabType == TabType.Fixed ? GridLength.Star : GridLength.Auto,
+                    Height = ((TabType == TabType.Fixed) && ((tabItem is not TabButton tabButton) || tabButton.ExpandToTabSize)) ? GridLength.Star : GridLength.Auto,
                 });
 
             if (TabType == TabType.Scrollable)
@@ -742,9 +740,30 @@ public partial class TabHostView : ContentView
     private void OnTabItemPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
         var tabItem = (TabItem)sender;
+        if (e.PropertyName == "ExpandToTabSize" && tabItem is TabButton tabButton)
+        {
+            UpdateTabButtonSize(tabButton);
+        }
+        else
         if (e.PropertyName == nameof(IsVisible))
         {
             UpdateTabVisibility(tabItem);
+        }
+    }
+
+    private void UpdateTabButtonSize(TabButton tabItem)
+    {
+        if (Orientation == OrientationType.Horizontal)
+        {
+            int columnIndex = Grid.GetColumn(tabItem);
+            ColumnDefinition columnDefinition = _grid.ColumnDefinitions[columnIndex];
+            columnDefinition.Width = tabItem.IsVisible ? (tabItem.ExpandToTabSize ? GridLength.Star : GridLength.Auto) : 0;
+        }
+        else
+        {
+            int rowIndex = Grid.GetRow(tabItem);
+            RowDefinition rowDefinition = _grid.RowDefinitions[rowIndex];
+            rowDefinition.Height = tabItem.IsVisible ? (tabItem.ExpandToTabSize ? GridLength.Star : GridLength.Auto) : 0;
         }
     }
 
@@ -753,13 +772,13 @@ public partial class TabHostView : ContentView
         if (Orientation == OrientationType.Horizontal)
         {
             int columnIndex = Grid.GetColumn(tabItem);
-            var columnDefinition = _grid.ColumnDefinitions[columnIndex];
+            ColumnDefinition columnDefinition = _grid.ColumnDefinitions[columnIndex];
             columnDefinition.Width = tabItem.IsVisible ? GridLength.Star : 0;
         }
         else
         {
             int rowIndex = Grid.GetRow(tabItem);
-            var rowDefinition = _grid.RowDefinitions[rowIndex];
+            RowDefinition rowDefinition = _grid.RowDefinitions[rowIndex];
             rowDefinition.Height = tabItem.IsVisible ? GridLength.Star : 0;
         }
     }


### PR DESCRIPTION
The problem: imagine you have a tab bar with a TabItem, a TabButton, and a TabItem. The width is 900 px. Each of the entries gets the width of 300 px (by default). The icons and texts of tabitems are centered within the provided 300 px (at positions cca 150 and 750 respectively). Now, if the TabButton is 60 px wide and is centered around point 450, you have a huge empty space from point 150 to point 420 - the distance between 0 and 150 is way lower than the distance between 150 and 420. The centered icon and text at point ~150 appear visually shifted to the left, and those at point ~750 appear shifted to the right. Now, if we give the button the width of 60 px, the left tab item would get the width of 420 px and the left icon and text would be centered  around point 210, and thus appear centered between the left edge and the button. The same would apply to the tab item. 

A similar problem, albeit less visible, would occur with four tab items and a tab button.  

The solution: included in this revision. It is optional and the default is the same as before in order not to break other users' design. 

A tab button can now be set to not take the full space (width for horizontal tab bars and height for vertical tab bars) of the bar item but be constrained to its necessary size. This lets other tab items be sized appropriately, taking all visible empty space and centering their icon or text appropriately. The behavior is controlled by the added ExpandToTabSize property of TabButton (the default value is true to keep the previous behavior).